### PR TITLE
docs: Fix a few typos

### DIFF
--- a/section_05_(loops)/zip_bingo.py
+++ b/section_05_(loops)/zip_bingo.py
@@ -1,6 +1,6 @@
 # Basic bingo using zip()
 
-words = ['apple', 'banana', 'carrot', 'danke', 'elephant', 'fruit', 'gorilla', 'horse, michael', 'ice cream', 'jack, one eye', 'kazoo', 'lollerskates', 'mango', 'noodles', 'oboe', 'porcupine', 'quill', 'rowboat', 'sailboat', 'trolley', 'umbrella', 'voltage', 'watermelon', 'xylophobe', 'yarn', 'zebra-clops']
+words = ['apple', 'banana', 'carrot', 'danke', 'elephant', 'fruit', 'gorilla', 'horse, michael', 'ice cream', 'jack, one eye', 'kazoo', 'lollerskates', 'mango', 'noodles', 'oboe', 'porcupine', 'quill', 'rowboat', 'sailboat', 'trolley', 'umbrella', 'voltage', 'watermelon', 'xylophone', 'yarn', 'zebra-clops']
 
 print "words has {0} words in the list.".format(len(words))
 
@@ -35,4 +35,4 @@ print output
 # fruit,gorilla,horse, michael,ice cream,jack, one eye,
 # kazoo,lollerskates,Free space,noodles,oboe,
 # porcupine,quill,rowboat,sailboat,trolley,
-# umbrella,voltage,watermelon,xylophobe,yarn,
+# umbrella,voltage,watermelon,xylophone,yarn,

--- a/section_11_(api)/dicts_and_lists.py
+++ b/section_11_(api)/dicts_and_lists.py
@@ -50,7 +50,7 @@ investigations = {
 
 # Each item in the features list is a dictionary that has three keys: type, geometry, and properties
 
-# If we wanted to access all of the properies for the first map point, here's how:
+# If we wanted to access all of the properties for the first map point, here's how:
 print investigations['features'][0]['properties']
 #   list of dictionaries ^       ^        ^
 #                first map point |        | properties

--- a/section_14_(exceptions)/exceptions_07.py
+++ b/section_14_(exceptions)/exceptions_07.py
@@ -1,6 +1,6 @@
 # Example #7: try-else
 
-# Use an else block attached to a try block when you want to execute code only when no errors occured.
+# Use an else block attached to a try block when you want to execute code only when no errors occurred.
 
 user_input = raw_input("Please enter a number: ")
 


### PR DESCRIPTION
There are small typos in:
- section_05_(loops)/zip_bingo.py
- section_11_(api)/dicts_and_lists.py
- section_14_(exceptions)/exceptions_07.py

Fixes:
- Should read `xylophone` rather than `xylophobe`.
- Should read `properties` rather than `properies`.
- Should read `occurred` rather than `occured`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md